### PR TITLE
Add simple frontend

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1,0 +1,23 @@
+const API_URL = "http://localhost:8000";
+
+export function getToken() {
+  return localStorage.getItem('token');
+}
+
+export function setToken(token) {
+  localStorage.setItem('token', token);
+}
+
+export function logout() {
+  localStorage.removeItem('token');
+}
+
+export async function api(path, options = {}) {
+  const token = getToken();
+  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  if (token) headers['Authorization'] = 'Bearer ' + token;
+  const res = await fetch(API_URL + path, { ...options, headers });
+  if (!res.ok) throw new Error(await res.text());
+  if (res.status === 204) return null;
+  return res.json();
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,26 @@
+import { api, setToken, getToken, logout } from './api.js';
+import Login from './login.js';
+import Feiras from './feiras.js';
+
+const e = React.createElement;
+
+function App() {
+  const [token, setTokenState] = React.useState(getToken());
+
+  function handleLogin(t) {
+    setToken(t);
+    setTokenState(t);
+  }
+
+  function handleLogout() {
+    logout();
+    setTokenState(null);
+  }
+
+  return e('div', null,
+    token ? e('button', { onClick: handleLogout }, 'Sair') : null,
+    token ? e(Feiras, { token }) : e(Login, { onLogin: handleLogin })
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/frontend/expositores.js
+++ b/frontend/expositores.js
@@ -1,0 +1,16 @@
+import { api } from './api.js';
+const e = React.createElement;
+
+export default function Expositores({ feiraId }) {
+  const [lista, setLista] = React.useState([]);
+
+  React.useEffect(() => {
+    if (feiraId) {
+      api('/expositores').then(data => setLista(data.filter(e => e.feira_id === feiraId))); 
+    }
+  }, [feiraId]);
+
+  return e('ul', null,
+    lista.map(exp => e('li', { key: exp.id }, exp.nome))
+  );
+}

--- a/frontend/feiras.js
+++ b/frontend/feiras.js
@@ -1,0 +1,42 @@
+import { api } from './api.js';
+const e = React.createElement;
+
+function FeiraItem({ feira, onSelect }) {
+  return e('li', { onClick: () => onSelect(feira) }, feira.nome);
+}
+
+export default function Feiras() {
+  const [feiras, setFeiras] = React.useState([]);
+  const [selected, setSelected] = React.useState(null);
+  const [form, setForm] = React.useState({ nome: '', descricao: '', data_inicio: '', data_fim: '', local: '', cidade: '', estado: '' });
+
+  React.useEffect(() => {
+    api('/feiras').then(setFeiras).catch(console.error);
+  }, []);
+
+  async function criar(evt) {
+    evt.preventDefault();
+    const nova = await api('/feiras', { method: 'POST', body: JSON.stringify(form) });
+    setFeiras([...feiras, nova]);
+  }
+
+  return e('div', null,
+    e('h3', null, 'Feiras'),
+    e('form', { onSubmit: criar },
+      Object.keys(form).map(campo =>
+        e('input', {
+          key: campo,
+          placeholder: campo,
+          value: form[campo],
+          onChange: e => setForm({ ...form, [campo]: e.target.value })
+        })
+      ),
+      e('button', { type: 'submit' }, 'Criar')
+    ),
+    e('ul', null, feiras.map(f => e(FeiraItem, { key: f.id, feira: f, onSelect: setSelected }))),
+    selected && e('div', null,
+      e('h4', null, selected.nome),
+      e('pre', null, JSON.stringify(selected, null, 2))
+    )
+  );
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Feiras Frontend</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script type="module" src="./app.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/frontend/ingressos.js
+++ b/frontend/ingressos.js
@@ -1,0 +1,35 @@
+import { api } from './api.js';
+const e = React.createElement;
+
+export default function Ingressos({ feiraId }) {
+  const [lista, setLista] = React.useState([]);
+  const [data, setData] = React.useState('');
+
+  React.useEffect(() => {
+    api('/ingressos').then(data => {
+      setLista(feiraId ? data.filter(i => i.feira_id === feiraId) : data);
+    });
+  }, [feiraId]);
+
+  async function criar(evt) {
+    evt.preventDefault();
+    const novo = await api('/ingressos', {
+      method: 'POST',
+      body: JSON.stringify({ feira_id: feiraId, data_emissao: data, numero: 'tmp' })
+    });
+    setLista([...lista, novo]);
+  }
+
+  return e('div', null,
+    e('h4', null, 'Ingressos'),
+    e('form', { onSubmit: criar },
+      e('input', {
+        type: 'date',
+        value: data,
+        onChange: e => setData(e.target.value)
+      }),
+      e('button', { type: 'submit' }, 'Criar')
+    ),
+    e('ul', null, lista.map(i => e('li', { key: i.id }, i.numero)))
+  );
+}

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -1,0 +1,38 @@
+import { api } from './api.js';
+const e = React.createElement;
+
+export default function Login({ onLogin }) {
+  const [email, setEmail] = React.useState('');
+  const [senha, setSenha] = React.useState('');
+  const [erro, setErro] = React.useState('');
+
+  async function handleSubmit(evt) {
+    evt.preventDefault();
+    try {
+      const data = await api('/usuarios/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, senha })
+      });
+      onLogin(data.access_token);
+    } catch (err) {
+      setErro('Falha no login');
+    }
+  }
+
+  return e('form', { onSubmit: handleSubmit },
+    e('h3', null, 'Login'),
+    erro ? e('div', { style: { color: 'red' } }, erro) : null,
+    e('input', {
+      placeholder: 'Email',
+      value: email,
+      onChange: e => setEmail(e.target.value)
+    }),
+    e('input', {
+      type: 'password',
+      placeholder: 'Senha',
+      value: senha,
+      onChange: e => setSenha(e.target.value)
+    }),
+    e('button', { type: 'submit' }, 'Entrar')
+  );
+}

--- a/frontend/produtos.js
+++ b/frontend/produtos.js
@@ -1,0 +1,16 @@
+import { api } from './api.js';
+const e = React.createElement;
+
+export default function Produtos({ expositorId }) {
+  const [lista, setLista] = React.useState([]);
+
+  React.useEffect(() => {
+    if (expositorId) {
+      api('/produtos').then(data => setLista(data.filter(p => p.expositor_id === expositorId)));
+    }
+  }, [expositorId]);
+
+  return e('ul', null,
+    lista.map(prod => e('li', { key: prod.id }, prod.nome + ' - R$ ' + prod.preco))
+  );
+}


### PR DESCRIPTION
## Summary
- add a minimal React frontend to interact with the FastAPI backend
- implement token storage in `localStorage`
- basic login form and fair CRUD example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a21980848832da745ea80268dab13